### PR TITLE
Readthedocs yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements_docs.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,5 @@ tox==3.5.2
 coverage==4.5.1
 Sphinx==1.8.1
 twine==1.12.1
-
+numpy
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -9,3 +9,4 @@ Sphinx==1.8.1
 twine==1.12.1
 nbsphinx
 IPython
+numpy


### PR DESCRIPTION
Add a yml config file for read the docs, which is their preferred way of configuring the build. This is needed to make sure nbsphinx is included correctly.